### PR TITLE
changed url update method

### DIFF
--- a/src/components/containers/sk-app/index.js
+++ b/src/components/containers/sk-app/index.js
@@ -39,7 +39,7 @@ export default class SkApp extends PolymerElement {
   }
 
   startTour() {
-    window.location.replace('https://github.com/PolymerX/polymer-skeleton');
+    window.location = 'https://github.com/PolymerX/polymer-skeleton';
   }
 
   reload() {


### PR DESCRIPTION
The `location.replace()` method does not add the initial page url to the browser's location history.  This allows the user to click the back button to return to their project.